### PR TITLE
requirements.txt to express a need for matplotlib 2.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+cycler==0.11.0
+fonttools==4.28.4
+kiwisolver==1.3.2
+matplotlib==2.1.2
+numpy==1.21.4
+packaging==21.3
+Pillow==8.4.0
+pyparsing==3.0.6
+python-dateutil==2.8.2
+pytz==2021.3
+scipy==1.7.3
+six==1.16.0


### PR DESCRIPTION
I was getting an error 
 `ImportError: cannot import name 'NavigationToolbar2TkAgg' from 'matplotlib.backends.backend_tkagg`
when running `teal.py` and traced it to having a higher version of matplotlib (neither 3.5 nor 2.2 worked).
This is resolved by explicitly installing matplotlib==2.1.2

This PR adds a requirements.txt that reflects a working config (on Linux)